### PR TITLE
Do not create an FSEventStream if there are no directories to monitor

### DIFF
--- a/include/fsevents/dir_monitor_impl.hpp
+++ b/include/fsevents/dir_monitor_impl.hpp
@@ -105,6 +105,11 @@ private:
 
     void start_fsevents()
     {
+        if (dirs_.size() == 0) {
+            fsevents_ = nullptr;
+            return;
+        }
+
         FSEventStreamContext context = {0, this, NULL, NULL, NULL};
         fsevents_ =
             FSEventStreamCreate(


### PR DESCRIPTION
Test case on OSX:
1.Add a directory to dir_monitor
2.Remove the directory added above from dir_monitor

Result:
FSEventStreamCreate fails because cannot allocate an array of size 0

Patch:
If there are no directories to monitor then don't bother creating the FSEventsStream.
Also fsevents_ must to be nulled to ensure the when fsevents_stop() is called it will only unsubscribe from a stream that was properly created.
