### PR TITLE
Fixed inotify implementation to process IN_MODIFY correctly and replaced many Boost libraries with C++11 analogues.

### DIFF
--- a/include/basic_dir_monitor.hpp
+++ b/include/basic_dir_monitor.hpp
@@ -49,7 +49,7 @@ inline std::ostream& operator << (std::ostream& os, dir_monitor_event const& ev)
             case boost::asio::dir_monitor_event::renamed_old_name: return "RENAMED (OLD NAME)";
             case boost::asio::dir_monitor_event::renamed_new_name: return "RENAMED (NEW NAME)";
             case boost::asio::dir_monitor_event::recursive_rescan: return "RESCAN DIR";
-            default: return "UKNOWN";
+            default: return "UNKNOWN";
         } } (ev.type) << " " << ev.path;
     return os;
 }

--- a/include/inotify/basic_dir_monitor_service.hpp
+++ b/include/inotify/basic_dir_monitor_service.hpp
@@ -8,15 +8,14 @@
 
 #include "dir_monitor_impl.hpp" 
 #include <boost/asio.hpp> 
-#include <boost/thread.hpp> 
 #include <boost/bind.hpp> 
-#include <boost/shared_ptr.hpp> 
-#include <boost/weak_ptr.hpp> 
-#include <boost/scoped_ptr.hpp> 
 #include <boost/filesystem.hpp> 
 #include <boost/system/error_code.hpp> 
+
+#include <memory>
 #include <string> 
 #include <stdexcept> 
+#include <thread>
 
 namespace boost { 
 namespace asio { 
@@ -50,7 +49,7 @@ public:
         async_monitor_thread_.join(); 
     } 
 
-    typedef boost::shared_ptr<DirMonitorImplementation> implementation_type; 
+    typedef std::shared_ptr<DirMonitorImplementation> implementation_type;
 
     void construct(implementation_type &impl) 
     { 
@@ -116,7 +115,7 @@ public:
         } 
 
     private: 
-        boost::weak_ptr<DirMonitorImplementation> impl_; 
+        std::weak_ptr<DirMonitorImplementation> impl_;
         boost::asio::io_service &io_service_; 
         boost::asio::io_service::work work_; 
         Handler handler_; 
@@ -134,8 +133,8 @@ private:
     } 
 
     boost::asio::io_service async_monitor_io_service_; 
-    boost::scoped_ptr<boost::asio::io_service::work> async_monitor_work_; 
-    boost::thread async_monitor_thread_; 
+    std::unique_ptr<boost::asio::io_service::work> async_monitor_work_;
+    std::thread async_monitor_thread_;
 }; 
 
 template <typename DirMonitorImplementation> 

--- a/include/inotify/dir_monitor_impl.hpp
+++ b/include/inotify/dir_monitor_impl.hpp
@@ -150,6 +150,7 @@ private:
                 { 
                 case IN_CREATE: type = dir_monitor_event::added; break; 
                 case IN_DELETE: type = dir_monitor_event::removed; break; 
+                case IN_MODIFY: type = dir_monitor_event::modified; break;
                 case IN_MOVED_FROM: type = dir_monitor_event::renamed_old_name; break; 
                 case IN_MOVED_TO: type = dir_monitor_event::renamed_new_name; break;
                 case IN_CREATE | IN_ISDIR:


### PR DESCRIPTION
1. Inotify impl wasn't processing IN_MODIFY event at all, so there was no modification event. Fixed.
2. Replaced boost libraries in inotify impl with C++11 analogues (where possible). Now we don't need linking to boost::thread library.

About C++11 libraries: Boost is great set of libs, but we have new standard now with lots of libraries, borrowed from boost.
It would be better to remove unnecessary dependencies if we have all that we need in standard library.