### PR TITLE
Remade compile-time OS detection with Boost.Predef.

### DIFF
--- a/include/dir_monitor.hpp
+++ b/include/dir_monitor.hpp
@@ -7,13 +7,15 @@
 #pragma once
 
 #include "basic_dir_monitor.hpp"
-#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#include <boost/predef/os.h>
+
+#if BOOST_OS_WINDOWS
 #  include "windows/basic_dir_monitor_service.hpp"
-#elif defined(linux) || defined(__linux) || defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)
+#elif BOOST_OS_LINUX
 #  include "inotify/basic_dir_monitor_service.hpp"
-#elif defined(__APPLE__) && defined(__MACH__)
+#elif BOOST_OS_MAC
 #  include "fsevents/basic_dir_monitor_service.hpp"
-#elif defined(__FreeBSD__)
+#elif BOOST_OS_BSD
 #  include "kqueue/basic_dir_monitor_service.hpp"
 #else
 #  error "Platform not supported."


### PR DESCRIPTION
Using Boost.Predef library for OS detection made code cleaner without this `#if defined(...)` spaghetti.
Also, we have kqueue not only on FreeBSD, but in other BSDs as well. And `BOOST_OS_BSD` detects all BSD variants correctly.

As this library is header-only and compile-time we don't add any overhead (size or dependencies) to binary.