### PR TITLE
fix build for os x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Header-only library
 #
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.2)
 include(Dart)
 
 # First, searching for dependencies

--- a/include/dir_monitor.hpp
+++ b/include/dir_monitor.hpp
@@ -13,7 +13,7 @@
 #  include "windows/basic_dir_monitor_service.hpp"
 #elif BOOST_OS_LINUX
 #  include "inotify/basic_dir_monitor_service.hpp"
-#elif BOOST_OS_MAC
+#elif BOOST_OS_MACOS
 #  include "fsevents/basic_dir_monitor_service.hpp"
 #elif BOOST_OS_BSD
 #  include "kqueue/basic_dir_monitor_service.hpp"


### PR DESCRIPTION
when using target_compile_features in cmake on os x and clang require a minimum version of 3.2, 3.1 does not support clang.

Hope it's ok to just bump the min version to 3.2.
