### PR TITLE
"implementation" and "service" members are considered as deprecated.

### DIFF
--- a/include/basic_dir_monitor.hpp
+++ b/include/basic_dir_monitor.hpp
@@ -66,31 +66,31 @@ public:
 
     void add_directory(const std::string &dirname)
     {
-        this->service.add_directory(this->implementation, dirname);
+        this->get_service().add_directory(this->get_implementation(), dirname);
     }
 
     void remove_directory(const std::string &dirname)
     {
-        this->service.remove_directory(this->implementation, dirname);
+        this->get_service().remove_directory(this->get_implementation(), dirname);
     }
 
     dir_monitor_event monitor()
     {
         boost::system::error_code ec;
-        dir_monitor_event ev = this->service.monitor(this->implementation, ec);
+        dir_monitor_event ev = this->get_service().monitor(this->get_implementation(), ec);
         boost::asio::detail::throw_error(ec);
         return ev;
     }
 
     dir_monitor_event monitor(boost::system::error_code &ec)
     {
-        return this->service.monitor(this->implementation, ec);
+        return this->get_service().monitor(this->get_implementation(), ec);
     }
 
     template <typename Handler>
     void async_monitor(Handler handler)
     {
-        this->service.async_monitor(this->implementation, handler);
+        this->get_service().async_monitor(this->get_implementation(), handler);
     }
 };
 


### PR DESCRIPTION
According to basic_io_object documentation (http://www.boost.org/doc/libs/release/doc/html/boost_asio/reference/basic_io_object.html) new code should use getters.