### PR TITLE
correct cmake version for the features used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 #
 # Header-only library
-#
-cmake_minimum_required(VERSION 2.8)
+
+# minimum 3.1 for target_compile_features: https://cmake.org/cmake/help/v3.1/command/target_compile_features.html
+# minimum 3.0 for target_include_directories: https://cmake.org/cmake/help/v3.0/command/target_include_directories.html
+cmake_minimum_required(VERSION 3.1)
 include(Dart)
 
 # First, searching for dependencies


### PR DESCRIPTION
It's a nice intention to make it cmake 2.8 compatible, but the features used require a higher version.
I didn't manage to replace the used directives with a 2.8 compatible version, so at least require the currently correct cmake version.
(Missing 2.8 compatibility is probably the main reason why this fails the Travis CI builds).