### PR TITLE
Hotfix/restore tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_script:
   - mkdir build
   - cd build
 script:
-  - cmake -DCMAKE_CXX_COMPILER=${COMPILER} ..
+  - cmake -DCMAKE_CXX_COMPILER=${COMPILER} -DBUILD_TESTING=ON ..
   - cmake --build .
-# - make test
-# As tests are in bad state now
+  - ctest --verbose 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,8 @@ before_script:
 script:
   - cmake -DCMAKE_CXX_COMPILER=${COMPILER} -DBUILD_TESTING=ON ..
   - cmake --build .
-  - ctest --verbose 
+#TODO: add support for osx
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+        ctest --verbose
+    fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,12 @@
 # minimum 3.1 for target_compile_features: https://cmake.org/cmake/help/v3.1/command/target_compile_features.html
 # minimum 3.0 for target_include_directories: https://cmake.org/cmake/help/v3.0/command/target_include_directories.html
 cmake_minimum_required(VERSION 3.1)
-include(Dart)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON) # Use the FOLDER target property to organize targets into folders
+
+if (BUILD_TESTING)
+    include(Dart)
+endif()
 
 # First, searching for dependencies
 set (BOOST_COMPONENTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(Boost COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 
 # Then, library itself
 add_library(dir_monitor INTERFACE)
-target_compile_features(dir_monitor INTERFACE cxx_generic_lambdas cxx_auto_type)
+target_compile_features(dir_monitor INTERFACE cxx_lambdas cxx_auto_type)
 target_include_directories(dir_monitor INTERFACE include)
 target_include_directories(dir_monitor INTERFACE ${Boost_INCLUDE_DIRS})
 

--- a/include/fsevents/dir_monitor_impl.hpp
+++ b/include/fsevents/dir_monitor_impl.hpp
@@ -218,7 +218,7 @@ private:
         runloop_cond_.notify_all();
     }
 
-    bool run_{false};
+    bool run_;
     CFRunLoopRef runloop_;
     boost::mutex runloop_mutex_;
     boost::condition_variable runloop_cond_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,9 +2,9 @@ include(CMakeParseArguments)
 
 function(create_test NAME)
     cmake_parse_arguments(CT "NO_CTEST" "" "LIBS" ${ARGN})
-    add_executable(test_${NAME} test_${NAME}.cpp)
+    add_executable(test_${NAME} test_${NAME}.cpp directory.hpp check_paths.hpp)
     target_link_libraries(test_${NAME} ${CT_LIBS} ${Boost_LIBRARIES} dir_monitor)
-    target_compile_definitions(test_${NAME} PRIVATE BOOST_TEST_DYN_LINK)
+    target_compile_definitions(test_${NAME} PRIVATE ${BOOST_TEST_LINK_MODE} BOOST_ASIO_ENABLE_HANDLER_TRACKING)
     install(TARGETS test_${NAME}
         RUNTIME DESTINATION tests/unittests)
     if (NOT CT_NO_CTEST)
@@ -18,6 +18,11 @@ if (APPLE)
     find_library(COREFOUNDATION_LIB CoreFoundation)
     find_library(CORESERVICES_LIB CoreServices)
 endif (APPLE)
+
+set(BOOST_TEST_LINK_MODE "BOOST_TEST_DYN_LINK")
+if (BOOST_TEST_STATIC_LINK)
+    set(BOOST_TEST_LINK_MODE "BOOST_TEST_NO_LIB")
+endif()
 
 create_test(sync LIBS ${Boost_LIBRARIES} ${COREFOUNDATION_LIB} ${CORESERVICES_LIB})
 create_test(async LIBS ${Boost_LIBRARIES} ${COREFOUNDATION_LIB} ${CORESERVICES_LIB})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CMakeParseArguments)
+
 function(create_test NAME)
     cmake_parse_arguments(CT "NO_CTEST" "" "LIBS" ${ARGN})
     add_executable(test_${NAME} test_${NAME}.cpp)
@@ -6,11 +8,11 @@ function(create_test NAME)
     install(TARGETS test_${NAME}
         RUNTIME DESTINATION tests/unittests)
     if (NOT CT_NO_CTEST)
-        add_test(${NAME} test_${NAME})
+        add_test(${NAME} test_${NAME} --build_info=yes --log_level=all)
     endif (NOT CT_NO_CTEST)
 endfunction(create_test)
 
-include_directories(.)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 if (APPLE)
     find_library(COREFOUNDATION_LIB CoreFoundation)
@@ -19,4 +21,5 @@ endif (APPLE)
 
 create_test(sync LIBS ${Boost_LIBRARIES} ${COREFOUNDATION_LIB} ${CORESERVICES_LIB})
 create_test(async LIBS ${Boost_LIBRARIES} ${COREFOUNDATION_LIB} ${CORESERVICES_LIB})
-create_test(running LIBS ${Boost_LIBRARIES} ${COREFOUNDATION_LIB} ${CORESERVICES_LIB})
+# TODO: this is not unit test module
+#create_test(running LIBS ${Boost_LIBRARIES} ${COREFOUNDATION_LIB} ${CORESERVICES_LIB})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,11 +13,16 @@ function(create_test NAME)
 endfunction(create_test)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_VERBOSE_MAKEFILE ON)
 
 if (APPLE)
     find_library(COREFOUNDATION_LIB CoreFoundation)
     find_library(CORESERVICES_LIB CoreServices)
 endif (APPLE)
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g")
+endif()
 
 set(BOOST_TEST_LINK_MODE "BOOST_TEST_DYN_LINK")
 if (BOOST_TEST_STATIC_LINK)

--- a/tests/check_paths.hpp
+++ b/tests/check_paths.hpp
@@ -1,0 +1,73 @@
+﻿#pragma once
+
+#include <boost/filesystem/path.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+struct splited_path
+{
+    splited_path(const boost::filesystem::path& p)
+        : m_path(split_path(p))
+    {
+    }
+
+    splited_path(const char* p)
+        : m_path(split_path(boost::filesystem::path(p)))
+    {
+    }
+
+    friend bool operator==(const splited_path& lhs, const splited_path& rhs)
+    {
+        const bool revert = lhs.m_path.size() > rhs.m_path.size();
+        const auto &x = revert ? rhs : lhs;
+        const auto &y = revert ? lhs : rhs;
+        if (!x.m_path.size())
+            return false;
+
+        const auto m = std::mismatch(x.m_path.rbegin(), x.m_path.rend(), y.m_path.rbegin());
+        return (m.first == x.m_path.rend());
+    }
+
+    std::vector<std::string> split_path(const boost::filesystem::path& p)
+    {
+        std::vector<std::string> result;
+        boost::split(result, p.generic_string(), boost::is_any_of("/"), boost::algorithm::token_compress_on);
+        boost::trim_if(result, [](const std::string& str) { return str.empty(); });
+        return result;
+    }
+
+private:
+    std::vector<std::string> m_path;
+};
+
+struct the_same_paths_relative_impl
+{
+    boost::test_tools::predicate_result operator()(splited_path const& left, splited_path const& right)
+    {
+        return left == right;
+    }
+};
+
+//  Special macro for checking if two paths (which can be both absolute/relative) is the same "file" path
+//
+//  Examples of using:
+//
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("d/b", "a/b");          =>  [x]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("/a/b", "a/b");         =>  [v]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("b", "a/b");            =>  [v]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("a", "a/b");            =>  [x]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("a/b", "c:/a/b");       =>  [v]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("c:/a/b", "a/b");       =>  [v]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("c:/a/b", "c:/a/b");    =>  [v]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("c:/a/b", "c:/a");      =>  [x]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("c:/a/b", "c:/a");      =>  [x]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("c:/a/b", "c:/d/b");    =>  [x]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("c:/a/b", "d:/a/b");    =>  [x]
+//      BOOST_CHECK_THE_SAME_PATHS_RELATIVE("", "d:/a/b");          =>  [x]
+
+#define BOOST_CHECK_THE_SAME_PATHS_RELATIVE( L, R ) \
+    BOOST_CHECK_WITH_ARGS_IMPL( the_same_paths_relative_impl(), "", CHECK, CHECK_EQUAL, (L)(R) )

--- a/tests/directory.hpp
+++ b/tests/directory.hpp
@@ -19,10 +19,10 @@ class directory
 {
 public:
     directory(const char *name)
-        : name_(boost::filesystem::complete(name))
+        : full_path(boost::filesystem::initial_path() / name)
     {
-        boost::filesystem::create_directory(name_);
-        BOOST_REQUIRE(boost::filesystem::is_directory(name_));
+        boost::filesystem::create_directory(full_path);
+        BOOST_REQUIRE(boost::filesystem::is_directory(full_path));
     }
 
     ~directory()
@@ -32,7 +32,7 @@ public:
         {
             try
             {
-                boost::filesystem::remove_all(name_);
+                boost::filesystem::remove_all(full_path);
                 again = false;
             }
             catch (...)
@@ -43,31 +43,33 @@ public:
         } while (again);
     }
 
-    void create_file(const char *file)
+    boost::filesystem::path create_file(const char *file)
     {
-        boost::filesystem::current_path(name_);
-        BOOST_REQUIRE(boost::filesystem::equivalent(name_, boost::filesystem::current_path()));
+        boost::filesystem::current_path(full_path);
+        BOOST_REQUIRE(boost::filesystem::equivalent(full_path, boost::filesystem::current_path()));
         std::ofstream ofs(file);
         BOOST_REQUIRE(boost::filesystem::exists(file));
         boost::filesystem::current_path(boost::filesystem::initial_path());
         BOOST_REQUIRE(boost::filesystem::equivalent(boost::filesystem::current_path(), boost::filesystem::initial_path()));
+        return full_path / file;
     }
 
-    void rename_file(const char *from, const char *to)
+    boost::filesystem::path rename_file(const char *from, const char *to)
     {
-        boost::filesystem::current_path(name_);
-        BOOST_REQUIRE(boost::filesystem::equivalent(name_, boost::filesystem::current_path()));
+        boost::filesystem::current_path(full_path);
+        BOOST_REQUIRE(boost::filesystem::equivalent(full_path, boost::filesystem::current_path()));
         BOOST_REQUIRE(boost::filesystem::exists(from));
         boost::filesystem::rename(from, to);
         BOOST_REQUIRE(boost::filesystem::exists(to));
         boost::filesystem::current_path(boost::filesystem::initial_path());
         BOOST_REQUIRE(boost::filesystem::equivalent(boost::filesystem::current_path(), boost::filesystem::initial_path()));
+        return full_path / to;
     }
 
     void remove_file(const char *file)
     {
-        boost::filesystem::current_path(name_);
-        BOOST_REQUIRE(boost::filesystem::equivalent(name_, boost::filesystem::current_path()));
+        boost::filesystem::current_path(full_path);
+        BOOST_REQUIRE(boost::filesystem::equivalent(full_path, boost::filesystem::current_path()));
         BOOST_REQUIRE(boost::filesystem::exists(file));
         boost::filesystem::remove(file);
         boost::filesystem::current_path(boost::filesystem::initial_path());
@@ -75,6 +77,6 @@ public:
     }
 
 private:
-    boost::filesystem::path name_;
+    boost::filesystem::path full_path;
 };
 

--- a/tests/test_async.cpp
+++ b/tests/test_async.cpp
@@ -152,9 +152,9 @@ BOOST_AUTO_TEST_CASE(blocked_async_call)
     boost::thread t;
 
     {
-        boost::asio::io_service io_service;
+        boost::asio::io_service local_io_service;
 
-        boost::asio::dir_monitor dm(io_service);
+        boost::asio::dir_monitor dm(local_io_service);
         dm.add_directory(TEST_DIR1);
 
         dm.async_monitor(blocked_async_call_handler_with_local_ioservice);
@@ -162,14 +162,13 @@ BOOST_AUTO_TEST_CASE(blocked_async_call)
         // run() is invoked on another thread to make async_monitor() call a blocking function.
         // When dm and io_service go out of scope they should be destroyed properly without
         // a thread being blocked.
-        t = boost::thread(boost::bind(&boost::asio::io_service::run, boost::ref(io_service)));
+        t = boost::thread(boost::bind(&boost::asio::io_service::run, boost::ref(local_io_service)));
         boost::system_time time = boost::get_system_time();
         time += boost::posix_time::time_duration(0, 0, 1);
         boost::thread::sleep(time);
     }
 
     t.join();
-    io_service.reset();
 }
 
 void unregister_directory_handler(const boost::system::error_code &ec, const boost::asio::dir_monitor_event &ev)


### PR DESCRIPTION
restore all test cases except ```test_running``` "suite" because this is not unit-test (by definition). i think ```test_running``` is a at least integration test or simple Example of ```dir_monitor``` async usage.

The job has been made under Win8.1/VS2013 (my native workstation) and Ubuntu12.01/gcc-5.2.1 (which is the same as in travis-ci build server). 
[CI results](https://travis-ci.org/sbelsky/dir_monitor)

Unfortunately i'm not familiar with MacOS at all. So tests under this OS were not provided. Hope somebody will do it.