### PR TITLE
Fixed: improper use of std::shared_from_this()

### DIFF
--- a/include/dir_monitor/basic_dir_monitor.hpp
+++ b/include/dir_monitor/basic_dir_monitor.hpp
@@ -68,12 +68,12 @@ public:
     {
     }
 
-    void add_directory(const std::string &dirname)
+    void add_directory(const std::string &dirname, bool recursive=true)
     {
-        this->get_service().add_directory(this->get_implementation(), dirname);
+        this->get_service().add_directory(this->get_implementation(), dirname, recursive);
     }
 
-    void remove_directory(const std::string &dirname)
+    void remove_directory(const std::string &dirname, bool recursive=true)
     {
         this->get_service().remove_directory(this->get_implementation(), dirname);
     }

--- a/include/dir_monitor/fsevents/basic_dir_monitor_service.hpp
+++ b/include/dir_monitor/fsevents/basic_dir_monitor_service.hpp
@@ -70,19 +70,19 @@ public:
         impl.reset();
     }
 
-    void add_directory(implementation_type &impl, const std::string &dirname)
+    void add_directory(implementation_type &impl, const std::string &dirname, bool recursive)
     {
         boost::filesystem::path dir(boost::filesystem::canonical(dirname));
         if (!boost::filesystem::is_directory(dir))
             throw std::invalid_argument("boost::asio::basic_dir_monitor_service::add_directory: " + dir.native() + " is not a valid directory entry");
 
-        impl->add_directory(dir);
+        impl->add_directory(dir, recursive);
     }
 
-    void remove_directory(implementation_type &impl, const std::string &dirname)
+    void remove_directory(implementation_type &impl, const std::string &dirname, bool recursive)
     {
         boost::filesystem::path dir(boost::filesystem::canonical(dirname));
-        impl->remove_directory(dir);
+        impl->remove_directory(dir, bool recursive);
     }
 
     /**

--- a/include/dir_monitor/fsevents/dir_monitor_impl.hpp
+++ b/include/dir_monitor/fsevents/dir_monitor_impl.hpp
@@ -40,7 +40,7 @@ public:
         stop_fsevents();
     }
 
-    void add_directory(boost::filesystem::path dirname)
+    void add_directory(boost::filesystem::path dirname, bool recursive)
     {
         boost::unique_lock<boost::mutex> lock(dirs_mutex_);
         dirs_.insert(dirname.native());//@todo Store path in dictionary
@@ -48,7 +48,7 @@ public:
         start_fsevents();
     }
 
-    void remove_directory(boost::filesystem::path dirname)
+    void remove_directory(boost::filesystem::path dirname, bool recursive)
     {
         boost::unique_lock<boost::mutex> lock(dirs_mutex_);
         dirs_.erase(dirname.native());

--- a/include/dir_monitor/inotify/basic_dir_monitor_service.hpp
+++ b/include/dir_monitor/inotify/basic_dir_monitor_service.hpp
@@ -123,8 +123,6 @@ private:
         // destroyed _after_ the thread is finished (not that the thread tries to access
         // instance properties which don't exist anymore).
         async_monitor_thread_.join();
-        
-        std::cout << "shutdown complete" << std::endl;
     }
 
     boost::asio::io_service async_monitor_io_service_;

--- a/include/dir_monitor/inotify/basic_dir_monitor_service.hpp
+++ b/include/dir_monitor/inotify/basic_dir_monitor_service.hpp
@@ -93,28 +93,7 @@ public:
             dir_monitor_event ev;
             if (impl)
                 ev = impl->popfront_event(ec);
-            PostAndWait(ec, ev);
-        }
-
-    protected:
-        void PostAndWait(const boost::system::error_code ec, const dir_monitor_event& ev) const
-        {
-            std::mutex post_mutex;
-            std::condition_variable post_condition_variable;
-            bool post_cancel = false;
-
-            this->io_service_.post(
-                [&]
-                {
-                    handler_(ec, ev);
-                    std::lock_guard<std::mutex> lock(post_mutex);
-                    post_cancel = true;
-                    post_condition_variable.notify_one();
-                }
-            );
-            std::unique_lock<std::mutex> lock(post_mutex);
-            while (!post_cancel)
-                post_condition_variable.wait(lock);
+            this->io_service_.post(boost::asio::detail::bind_handler(handler_, ec, ev));
         }
 
     private:

--- a/include/dir_monitor/inotify/basic_dir_monitor_service.hpp
+++ b/include/dir_monitor/inotify/basic_dir_monitor_service.hpp
@@ -56,17 +56,17 @@ public:
         impl.reset();
     }
 
-    void add_directory(implementation_type &impl, const std::string &dirname)
+    void add_directory(implementation_type &impl, const std::string &dirname, bool recursive)
     {
         if (!boost::filesystem::is_directory(dirname))
             throw std::invalid_argument("boost::asio::basic_dir_monitor_service::add_directory: " + dirname + " is not a valid directory entry");
 
-        impl->add_directory(dirname);
+        impl->add_directory(dirname, recursive);
     }
 
-    void remove_directory(implementation_type &impl, const std::string &dirname)
+    void remove_directory(implementation_type &impl, const std::string &dirname, bool recursive)
     {
-        impl->remove_directory(dirname);
+        impl->remove_directory(dirname, recursive);
     }
 
     dir_monitor_event monitor(implementation_type &impl, boost::system::error_code &ec)

--- a/include/dir_monitor/inotify/dir_monitor_impl.hpp
+++ b/include/dir_monitor/inotify/dir_monitor_impl.hpp
@@ -27,8 +27,7 @@
 namespace boost {
 namespace asio {
 
-class dir_monitor_impl :
-    public std::enable_shared_from_this<dir_monitor_impl>
+class dir_monitor_impl
 {
 public:
     dir_monitor_impl()
@@ -142,7 +141,7 @@ public:
     void begin_read()
     {
         stream_descriptor_->async_read_some(boost::asio::buffer(read_buffer_),
-            boost::bind(&dir_monitor_impl::end_read, shared_from_this(),
+            boost::bind(&dir_monitor_impl::end_read, this,
             boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
     }
 

--- a/include/dir_monitor/kqueue/dir_monitor_impl.hpp
+++ b/include/dir_monitor/kqueue/dir_monitor_impl.hpp
@@ -36,7 +36,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/ptr_container/ptr_unordered_map.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/system/system_error.hpp>
 #include <string>
@@ -54,8 +53,7 @@
 namespace boost {
 namespace asio {
 
-class dir_monitor_impl :
-    public boost::enable_shared_from_this<dir_monitor_impl>
+class dir_monitor_impl
 {
     class unix_handle
         : public boost::noncopyable


### PR DESCRIPTION
Local use of `std::shared_from_this()` via `std::bind()` resulted in std::function being stored in local `io_service`, thus a loop was created preventing the shared_ptr instance count from reaching zero, thus leaking memory.