### PR TITLE
Fixed: improper use of std::shared_from_this()

### DIFF
--- a/include/dir_monitor/inotify/dir_monitor_impl.hpp
+++ b/include/dir_monitor/inotify/dir_monitor_impl.hpp
@@ -27,8 +27,7 @@
 namespace boost {
 namespace asio {
 
-class dir_monitor_impl :
-    public std::enable_shared_from_this<dir_monitor_impl>
+class dir_monitor_impl
 {
 public:
     dir_monitor_impl()
@@ -142,7 +141,7 @@ public:
     void begin_read()
     {
         stream_descriptor_->async_read_some(boost::asio::buffer(read_buffer_),
-            boost::bind(&dir_monitor_impl::end_read, shared_from_this(),
+            boost::bind(&dir_monitor_impl::end_read, this,
             boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
     }
 

--- a/include/dir_monitor/kqueue/dir_monitor_impl.hpp
+++ b/include/dir_monitor/kqueue/dir_monitor_impl.hpp
@@ -36,7 +36,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/ptr_container/ptr_unordered_map.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/system/system_error.hpp>
 #include <string>
@@ -54,8 +53,7 @@
 namespace boost {
 namespace asio {
 
-class dir_monitor_impl :
-    public boost::enable_shared_from_this<dir_monitor_impl>
+class dir_monitor_impl
 {
     class unix_handle
         : public boost::noncopyable


### PR DESCRIPTION
Local use of std::shared_from_this() in std::bind() stored in
local io_service prevented class from ever being deleted, thus
leaking memory.