### PR TITLE
Removed unnecessary converting to utf8

### DIFF
--- a/include/dir_monitor/windows/basic_dir_monitor_service.hpp
+++ b/include/dir_monitor/windows/basic_dir_monitor_service.hpp
@@ -293,7 +293,7 @@ private:
                 case FILE_ACTION_RENAMED_OLD_NAME: type = dir_monitor_event::renamed_old_name; break;
                 case FILE_ACTION_RENAMED_NEW_NAME: type = dir_monitor_event::renamed_new_name; break;
                 }
-                impl->pushback_event(dir_monitor_event(boost::filesystem::path(ck_holder->dirname) / helper::to_utf8(fni->FileName, fni->FileNameLength / sizeof(WCHAR)), type));
+                impl->pushback_event(dir_monitor_event(boost::filesystem::path(ck_holder->dirname) / std::wstring(fni->FileName, fni->FileNameLength / sizeof(WCHAR)), type));
                 offset += fni->NextEntryOffset;
             } while (fni->NextEntryOffset);
 


### PR DESCRIPTION
The boost path used wchar_t on Windows.
On Czech Windows there was an error: the resulting utf8 string has odd chars, that was incorrectly converted back to wchar in boost path class.