### PR TITLE
 Translate IN_ATTRIB to IN_MODIFY

### DIFF
--- a/include/dir_monitor/inotify/basic_dir_monitor_service.hpp
+++ b/include/dir_monitor/inotify/basic_dir_monitor_service.hpp
@@ -90,28 +90,8 @@ public:
             dir_monitor_event ev;
             if (impl)
                 ev = impl->popfront_event(ec);
-            PostAndWait(ec, ev);
-        }
-
-    protected:
-        void PostAndWait(const boost::system::error_code ec, const dir_monitor_event& ev) const
-        {
-            std::mutex post_mutex;
-            std::condition_variable post_condition_variable;
-            bool post_cancel = false;
-
-            this->io_service_.post(
-                [&]
-                {
-                    handler_(ec, ev);
-                    std::lock_guard<std::mutex> lock(post_mutex);
-                    post_cancel = true;
-                    post_condition_variable.notify_one();
-                }
-            );
-            std::unique_lock<std::mutex> lock(post_mutex);
-            while (!post_cancel)
-                post_condition_variable.wait(lock);
+            if(ec != boost::asio::error::operation_aborted)
+                this->io_service_.post(boost::asio::detail::bind_handler(handler_, ec, ev));
         }
 
     private:
@@ -141,8 +121,6 @@ private:
         // destroyed _after_ the thread is finished (not that the thread tries to access
         // instance properties which don't exist anymore).
         async_monitor_thread_.join();
-        
-        std::cout << "shutdown complete" << std::endl;
     }
 
     boost::asio::io_service async_monitor_io_service_;

--- a/include/dir_monitor/inotify/dir_monitor_impl.hpp
+++ b/include/dir_monitor/inotify/dir_monitor_impl.hpp
@@ -41,7 +41,7 @@ public:
 
     void add_directory(const std::string &dirname)
     {
-        int wd = inotify_add_watch(fd_, dirname.c_str(), IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO);
+        int wd = inotify_add_watch(fd_, dirname.c_str(), IN_CREATE | IN_DELETE | IN_ATTRIB | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO);
         if (wd == -1)
         {
             boost::system::system_error e(boost::system::error_code(errno, boost::system::get_system_category()), "boost::asio::dir_monitor_impl::add_directory: inotify_add_watch failed");
@@ -159,7 +159,9 @@ private:
                 {
                 case IN_CREATE: type = dir_monitor_event::added; break;
                 case IN_DELETE: type = dir_monitor_event::removed; break;
-                case IN_MODIFY: type = dir_monitor_event::modified; break;
+                case IN_ATTRIB:
+                case IN_MODIFY: type = dir_monitor_event::modified;
+                    break;
                 case IN_MOVED_FROM: type = dir_monitor_event::renamed_old_name; break;
                 case IN_MOVED_TO: type = dir_monitor_event::renamed_new_name; break;
                 case IN_CREATE | IN_ISDIR:


### PR DESCRIPTION
Inotify has a separate event for attribute changes (changes to permissions, timestamps, etc.) (see [inotify man pages](http://linux.die.net/man/7/inotify)). Translate `IN_ATTRIB` to a `dir_monitor_event::modified` event, to be consistent with e.g. the windows implementation.